### PR TITLE
changed some variable types

### DIFF
--- a/CoolProp/CoolPropTools.cpp
+++ b/CoolProp/CoolPropTools.cpp
@@ -34,7 +34,7 @@ std::string format(const char* fmt, ...)
     }
     std::string ret(buffer);
     va_end(vl);
-    delete buffer;
+    delete[] buffer;
     return ret;
 }
 

--- a/CoolProp/IncompBase.cpp
+++ b/CoolProp/IncompBase.cpp
@@ -185,10 +185,10 @@ std::vector<double> IncompressibleClass::fracIntCentralDvector(int m, double T, 
 	std::vector<double> D;
 	double tmp;
 	if (m<1) throw ValueError(format("You have to provide coefficients, a vector length of %d is not a valid. ",m));
-	for (unsigned int j=0; j<m; j++){ // loop through row
-		tmp = pow(-1.0,(int)j) * log(T) * pow(Tbase,(int)j);
-		for(unsigned int k=0; k<j; k++) { // internal loop for every entry
-			tmp += binom(j,k) * pow(-1.0,(int)k) / (j-k) * pow(T,(int)(j-k)) * pow(Tbase,(int)k);
+	for (int j=0; j<m; j++){ // loop through row
+		tmp = pow(-1.0,j) * log(T) * pow(Tbase,(int)j);
+		for(int k=0; k<j; k++) { // internal loop for every entry
+			tmp += binom(j,k) * pow(-1.0,k) / (j-k) * pow(T,j-k) * pow(Tbase,k);
 		}
 		D.push_back(tmp);
 	}

--- a/CoolProp/TTSE.cpp
+++ b/CoolProp/TTSE.cpp
@@ -650,8 +650,8 @@ bool TTSESinglePhaseTableClass::read_all_from_file(std::string root_path)
 	// Didn't work since at least one of the parameters was different
 	// so we need to build the tables again
 	if (!(!Fluid.compare(pFluid->get_name())
-		  && Nh == this->Nh
-		  && Np == this->Np
+		  && Nh == (int)this->Nh
+		  && Np == (int)this->Np
 		  && fabs(pmin - this->pmin)<10*DBL_EPSILON
 		  && fabs(pmax - this->pmax)<10*DBL_EPSILON
 		  && fabs(hmin - this->hmin)<10*DBL_EPSILON
@@ -2582,14 +2582,14 @@ double TTSETwoPhaseTableClass::evaluate(long iParam, double p)
 	// or between the critical pressure and the next lowest point,
 	// just just the next lowest point to avoid some of the 
 	// derivatives that are infinite at the critical point
-	if (i == N || i == N-1 ) i = N-2;
+	if (i == (int)N || i == (int)N-1 ) i = N-2;
 	// If it is really out of the range, throw an error
 	if (i<0 || i>(int)N-1)
 	{
 		throw ValueError(format("p [%g] is out of range[%g,%g], yielded index of: %d",p,pmin,pmax,i));
 	}
 
-	if (i == N-2)
+	if (i == (int)N-2)
 	{
 		double y1, yc, dydp1;
 		switch (iParam)
@@ -2726,7 +2726,7 @@ double TTSETwoPhaseTableClass::evaluate_sat_derivative(long iParam, double p)
 	// If the value is just a little bit out of the range, clip 
 	// it back to the range of the LUT
 	if (i == -1) i = 0;
-	if (i == N) i = N-1;
+	if (i == (int)N) i = N-1;
 	// If it is really out of the range, throw an error
 	if (i<0 || i>(int)N-1)
 	{


### PR DESCRIPTION
Sorry, this was really pedantic - I was just looking at the valgrind output and spotted some of these (well only the delete one) and went though some of the gcc errors about unsigned ints. I'm not sure if you were using the unsigned int rule or just using them normally.

Also there are a significant number of warnings/errors highligted by valgrind regarding uninitialized values in:

``` c++
phi0_power::dTau(double, double) (Helmholtz.h line 711), and
phi0_power::base(double, double) (Helmholtz.h line 702).
```

Anyway, feel free to ignore this patch! :+1: 
