### PR TITLE
Added T-s value pair for definition of fluid states

### DIFF
--- a/CoolProp/CPState.h
+++ b/CoolProp/CPState.h
@@ -130,6 +130,9 @@ protected:
 	// To be used to update internal variables if you know that your parameters are H,S
 	void update_hs(long iInput1, double Value1, long iInput2, double Value2);
 
+	// To be used to update internal variables if you know that your parameters are T,S
+	void update_Ts(long iInput1, double Value1, long iInput2, double Value2);
+
 	// Update using the TTSE lookup tables
 	void update_TTSE_LUT(long iInput1, double Value1, long iInput2, double Value2);
 

--- a/CoolProp/FluidClass.cpp
+++ b/CoolProp/FluidClass.cpp
@@ -2723,7 +2723,7 @@ void Fluid::density_Ts(double T, double s, double *rhoout, double *pout, double 
 	{
 		rhoFuncClass rhoFunc(T, s, this);
 		std::string errstr;
-		*rhoout = Secant(&rhoFunc, rho_guess, 1, 1e-8, 100, &errstr);
+		*rhoout = BoundedSecant(&rhoFunc, rho_guess, 0.0, 1e10, 0.1*rho_guess, 1e-8, 100, &errstr);
 		*pout = pressure_Trho(T, *rhoout);
 	}
 }

--- a/CoolProp/FluidClass.cpp
+++ b/CoolProp/FluidClass.cpp
@@ -2634,6 +2634,98 @@ void Fluid::temperature_hs(double h, double s, double *Tout, double *rhoout, dou
 	*rhoout = delta*reduce.rho;
 }
 
+void Fluid::density_Ts(double T, double s, double *rhoout, double *pout, double *rhoLout, double *rhoVout, double *psatLout, double *psatVout)
+{
+	double rho_guess;
+	bool _SinglePhase;
+
+	// Density is solved from entropy_Trho method for single phase and from
+	// saturation information for two-phase. First get the phase.
+	if (T >= crit.T)
+	{
+		_SinglePhase = true;
+		rho_guess = crit.p.Pa/R()/T;
+	}
+	else
+	{
+		// T < crit.T
+		// First try to define the phase with the ancillary equations, if we are
+		// far enough away from saturation.
+		if (s < 0.95*ssatL_anc(T))
+		{
+			// liquid
+			_SinglePhase = true;
+			rho_guess = rhosatL(T);
+		}
+		else if (s > 1.05*ssatV_anc(T))
+		{
+			// superheated vapor
+			_SinglePhase = true;
+			rho_guess = params.ptriple/R()/T;
+		}
+		else
+		{
+			// Actually have to use saturation information sadly
+			// For the given temperature, find the saturation state
+			// Run the saturation routines to determine the saturation densities and pressures
+			saturation_T(T, enabled_TTSE_LUT, psatLout, psatVout, rhoLout, rhoVout);
+			double sL = entropy_Trho(T, *rhoLout);
+			double sV = entropy_Trho(T, *rhoVout);
+			double Q = (s-sL)/(sV-sL);
+			if (Q < -100*DBL_EPSILON)
+			{
+				// liquid
+				_SinglePhase = true;
+				rho_guess = rhosatL(T);
+			}
+			else if (Q > 1+100*DBL_EPSILON)
+			{
+				// superheated vapor
+				_SinglePhase = true;
+				rho_guess = params.ptriple/R()/T;
+			}
+			else
+			{
+				// two-phase
+				// Return the quality weighted values
+				_SinglePhase = false;
+				*rhoout = 1/(Q/ *rhoVout +(1-Q)/ *rhoLout);
+				*pout = Q* *psatVout +(1-Q)* *psatLout;
+				return;
+			}
+		}
+	}
+
+	// Function class for iterative solution of entropy_Trho for rho
+	class rhoFuncClass : public FuncWrapper1D
+	{
+	private:
+		    double T, s;
+		    Fluid *pFluid;
+	public:
+		    rhoFuncClass(double T, double s, Fluid *pFluid)
+			{
+		        this->T = T;
+		        this->s = s;
+		        this->pFluid = pFluid;
+		    };
+
+		    double call(double rho)
+		    {
+		        return pFluid->entropy_Trho(T, rho) - s;
+		    };
+	};
+
+	// Calculate density and pressure for single phase states
+	if (_SinglePhase == true)
+	{
+		rhoFuncClass rhoFunc(T, s, this);
+		std::string errstr;
+		*rhoout = Secant(&rhoFunc, rho_guess, 1, 1e-8, 100, &errstr);
+		*pout = pressure_Trho(T, *rhoout);
+	}
+}
+
 double Fluid::Tsat_anc(double p, double Q)
 {
 	// This one only uses the ancillary equations

--- a/CoolProp/FluidClass.h
+++ b/CoolProp/FluidClass.h
@@ -297,6 +297,15 @@ class Fluid
 		virtual double density_Tp(double T, double p);
 		virtual double density_Tp(double T, double p, double rho_guess);
 
+		/// Density as a function of temperature and entropy
+		/// @param T Temperature [K]
+		/// @param s Entropy [kJ/kg/K]
+		/// @param rhoout Density [kg/m^3]
+		/// @param pout Pressure [kPa]
+		/// @param rhoLout Saturated liquid density [kg/m^3]
+		/// @param rhoVout Saturated vapor density [kg/m^3]
+		virtual void density_Ts(double T, double s, double *rhoout, double *pout, double *rhoLout, double *rhoVout, double *psatLout, double *psatVout);
+
 		/// Temperature as a function of pressure and entropy
 		/// @param h Enthalpy [kJ/kg/K]
 		/// @param s Entropy [kJ/kg/K]

--- a/CoolProp/gitrevision.h
+++ b/CoolProp/gitrevision.h
@@ -1,1 +1,1 @@
-std::string gitrevision = "4a211c0efdacc7b9b44d12a25610b81f9dfa87ac";
+std::string gitrevision = "f3297e9dd5ceeb8051bc79c968ab698cd3827c5d";

--- a/CoolProp/gitrevision.h
+++ b/CoolProp/gitrevision.h
@@ -1,1 +1,1 @@
-std::string gitrevision = "f3297e9dd5ceeb8051bc79c968ab698cd3827c5d";
+std::string gitrevision = "9680508165c1b9e60576e4aeb5f4e83adf299ed0";

--- a/CoolProp/gitrevision.h
+++ b/CoolProp/gitrevision.h
@@ -1,1 +1,1 @@
-std::string gitrevision = "9680508165c1b9e60576e4aeb5f4e83adf299ed0";
+std::string gitrevision = "ea8525e58e89408dfb75f018077b4e2f9aeac278";

--- a/CoolProp/gitrevision.h
+++ b/CoolProp/gitrevision.h
@@ -1,1 +1,1 @@
-std::string gitrevision = "ea8525e58e89408dfb75f018077b4e2f9aeac278";
+std::string gitrevision = "7299dc06720bd7b5a81f8099438083c465e1fe85";

--- a/wrappers/Python/CoolProp/CoolProp.pyx
+++ b/wrappers/Python/CoolProp/CoolProp.pyx
@@ -317,6 +317,7 @@ cpdef Props(str in1, str in2, in3 = None, in4 = None, in5 = None, in6 = None, in
     ``H``                      ``P``
     ``S``                      ``P``
     ``S``                      ``H``
+    ``T``                      ``S`` 
     =========================  ======================================
     
     **Python Only** : InputProp1 and InputProp2 can be lists or numpy arrays.  If both are iterables, they must be the same size. 

--- a/wrappers/Python/CoolProp/tests/test_consistency.py
+++ b/wrappers/Python/CoolProp/tests/test_consistency.py
@@ -15,8 +15,8 @@ modes.append('pure')
 ## except ValueError:
 ##     pass
             
-twophase_inputs = [('T','D'),('T','Q'),('P','Q'),('P','H'),('P','S'),('P','D'),('H','S')]
-singlephase_inputs = [('T','D'),('T','P'),('P','H'),('P','S'),('P','D'),('H','S')]
+twophase_inputs = [('T','D'),('T','Q'),('P','Q'),('P','H'),('P','S'),('P','D'),('H','S'),('T','S')]
+singlephase_inputs = [('T','D'),('T','P'),('P','H'),('P','S'),('P','D'),('H','S'),('T','S')]
 
 singlephase_outputs = ['T','P','H','S','A','O','C','G','V','L','C0','U']
 


### PR DESCRIPTION
Included (T,s) value pairs for instantiation of Props and State classes as discussed in #117 and #118.
- The new value pair was also added to the consistency test: `test_subcrit_twophase_consistency()` works for (T,s) pairs with all fluids
- Updated API doc
