### PR TITLE
RF: use setuptools for setup.py when it's there

### DIFF
--- a/wrappers/Python/setup.py
+++ b/wrappers/Python/setup.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+# Use setuptools version of distutils if available
+try:
+    import setuptools
+except ImportError:
+    pass
 #Check for cython >= 0.17 due to the use of STL containers
 try:
     import Cython


### PR DESCRIPTION
Use setuptools version of distutils when available so setuptools extensions
work, such as bdist_mpkg and bdist_wheel.
