### PR TITLE
Fixed bug with iterables in Props and PropsSI

### DIFF
--- a/wrappers/Python/CoolProp/CoolProp.pyx
+++ b/wrappers/Python/CoolProp/CoolProp.pyx
@@ -336,12 +336,12 @@ cpdef Props(in1, in2, in3 = None, in4 = None, in5 = None, in6 = None, in7 = None
         else:
             if iterable(in5) and not iterable(in3):
                 in3, in5 = in5, in3 # swap 3 and 5 so 3 is the iterable
-                in2, in4 = in4, in2 # swap their keys too
+                _in2, _in4 = _in4, _in2 # swap their keys too
             vals = []
             for _in3 in in3:
                 val = _Props(_in1, _in2, _in3, _in4, in5, _in6)
                 if not _ValidNumber(val):
-                    __Props_err2(in1,in2,_in3,in4,in5,in6,_get_global_param_string('errstring'))
+                    __Props_err2(in1,_in2,_in3,_in4,in5,in6,_get_global_param_string('errstring'))
                 vals.append(val)
             return ndarray_or_iterable(vals)
        
@@ -470,12 +470,12 @@ cpdef PropsSI(in1, in2, in3 = None, in4 = None, in5 = None, in6 = None, in7 = No
         else:
             if iterable(in5) and not iterable(in3):
                 in3, in5 = in5, in3 # swap 3 and 5 so 3 is the iterable
-                in2, in4 = in4, in2 # swap their keys too
+                _in2, _in4 = _in4, _in2 # swap their keys too
             vals = []
             for _in3 in in3:
                 val = _PropsSI(_in1, _in2, _in3, _in4, in5, _in6)
                 if not _ValidNumber(val):
-                    __PropsSI_err2(in1,in2,_in3,in4,in5,in6,_get_global_param_string('errstring'))
+                    __PropsSI_err2(in1,_in2,_in3,_in4,in5,in6,_get_global_param_string('errstring'))
                 vals.append(val)
             return ndarray_or_iterable(vals)
 

--- a/wrappers/Python/CoolProp/tests/test_Props.py
+++ b/wrappers/Python/CoolProp/tests/test_Props.py
@@ -13,6 +13,10 @@ def test_input_types():
 
 def check_type(fluid, Tvals):
     Props('P','T',Tvals,'Q',0,fluid)
+
+def test_iterable_inputs():
+    Props('P','T',[280,290,300],'Q',0,'R134a')
+    Props('P','Q',0,'T',[280,290,300],'R134a')
     
 class PropsFailures(unittest.TestCase):
     def testUnmatchedLengths(self):

--- a/wrappers/Python/CoolProp/tests/test_PropsSI.py
+++ b/wrappers/Python/CoolProp/tests/test_PropsSI.py
@@ -1,0 +1,29 @@
+import unittest
+from CoolProp.CoolProp import PropsSI
+import CoolProp
+import numpy as np
+       
+def test_input_types():
+    for Fluid in ['Water']:
+        for Tvals in [0.5*PropsSI(Fluid,'Tmin')+0.5*PropsSI(Fluid,'Tcrit'),
+                      [PropsSI(Fluid,'Tmin')+1e-5,PropsSI(Fluid,'Tcrit')-1e-5],
+                      np.linspace(PropsSI(Fluid,'Tmin')+1e-5, PropsSI(Fluid,'Tcrit')-1e-5,30)
+                      ]:
+            yield check_type, Fluid, Tvals
+
+def check_type(fluid, Tvals):
+    PropsSI('P','T',Tvals,'Q',0,fluid)
+
+def test_iterable_inputs():
+    PropsSI('P','T',[280,290,300],'Q',0,'R134a')
+    PropsSI('P','Q',0,'T',[280,290,300],'R134a')
+    
+class PropsSIFailures(unittest.TestCase):
+    def testUnmatchedLengths(self):
+        self.assertRaises(TypeError,PropsSI,'P','T',[280,290,300],'Q',[0,1],'R134a')
+    def testMatrix(self):
+        self.assertRaises(TypeError,PropsSI,'P','T',np.array([280,290,300,280,290,300]).reshape(2,3),'Q',np.array([0,0.5,1,0.0,0.5,1]).reshape(2,3),'R134a')
+
+if __name__=='__main__':
+    import nose
+    nose.runmodule()


### PR DESCRIPTION
There was an bug in swapping of arguments for Props and PropsSI methods, if the arguments contained iterables. I have also added unittests to catch these things...
