### PR TITLE
Update_LB_README.rst

### DIFF
--- a/wrappers/Octave/README.rst
+++ b/wrappers/Octave/README.rst
@@ -4,11 +4,11 @@ This CoolProp.oct module is built using SWIG, and is built for octave for window
 
 Installation
 ============
-Separate versions of the .oct file are available for Octave 3.6.1 and 3.6.2.
+Separate versions of the .oct file are available for Octave 3.6.1 and 3.6.2. Version 3.8.0 is currently aviable in Ubuntu 14.04 repositories. 
 Put the .oct file for the version you have in somewhere in the octave path, or use the ``addpath`` function to add the folder that contains CoolProp.oct to the Octave path
 
 On Linux systems you can put .oct file in
-"/usr/share/octave/?octave.version.number?/m" folder. You will need superuser
+"/usr/share/octave/octave.version.number/m" folder. You will need superuser
 privileges to do this.
 
 If you place .oct file somewhere outside octave path, you have to use
@@ -31,11 +31,11 @@ B. In the win32 distro of 3.6.2, the hard-coded path in OCTAVE/bin/include/math.
 depending on where your VS is installed
 
 
-Building on Linux (Ubuntu in this case)
+Building on Linux (Ubuntu and derivatives)
 ---------------------------------------
 1. You will need to run 
       sudo apt-get update
-      sudo apt-get install octave liboctave-dev swig
+      sudo apt-get install octave liboctave-dev swig subversion
    to install the necesary dependencies.  The install of octave might not be necessary but it cant hurt
 2. Check out the full source for coolprop from github
       git clone https://github.com/ibell/coolprop
@@ -46,6 +46,29 @@ Building on Linux (Ubuntu in this case)
 5. Call
       octave sample_code.m
    to run the sample
+
+
+Building on Linux (openSUSE)
+---------------------------------------
+1. In YaST program manager select for installation the following libraries: 
+      octave
+      octave-devel
+      octave-doc
+      octave-mathgl
+      plplot-octave
+      swig
+      subversion
+   Accept the install of the additional necessary dependencies. The install of octave might not be necessary but it cant hurt
+2. Check out the full source for coolprop from github
+      git clone https://github.com/ibell/coolprop
+3. Change into the coolprop-code/wrappers/Octave folder
+      cd coolprop/wrappers/Octave
+4. Call
+      octave _OctaveBuilder_Linux.m
+5. Call
+      octave sample_code.m
+   to run the sample
+
    
 Building on Raspberry PI
 ------------------------


### PR DESCRIPTION
Full support for Octave ver 3.8.0 will be aviable in swig2.0 ver 2.0.12
Added enty "subversion" in Ubuntu install.
Added Building on Linux (openSUSE)

Version 3.8.0 tested on Xubuntu 14.04 Beta-1
