### PR TITLE
Added easy plotting of cycles (closes #174)

### DIFF
--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -12,12 +12,19 @@ SMALL = 1E-5
 
 class BasePlot(object):
     #TODO: Simplify / Consolidate dictionary maps
-    AXIS_LABELS = {'T': ["Temperature", r"[K]"],
-                   'P': ["Pressure", r"[kPa]"],
-                   'S': ["Entropy", r"[kJ/kg/K]"],
-                   'H': ["Enthalpy", r"[kJ/kg]"],
-                   'V': [],
-                   'D': ["Density", r"[kg/m$^3$]"]}
+    AXIS_LABELS = {'kSI': {'T': ["Temperature", r"[K]"],
+                           'P': ["Pressure", r"[kPa]"],
+                           'S': ["Entropy", r"[kJ/kg/K]"],
+                           'H': ["Enthalpy", r"[kJ/kg]"],
+                           'V': [],
+                           'D': ["Density", r"[kg/m$^3$]"]},
+                   'SI' : {'T': ["Temperature", r"[K]"],
+                           'P': ["Pressure", r"[Pa]"],
+                           'S': ["Entropy", r"[J/kg/K]"],
+                           'H': ["Enthalpy", r"[J/kg]"],
+                           'V': [],
+                           'D': ["Density", r"[kg/m$^3$]"]}
+                  }
 
     COLOR_MAP = {'T': 'Darkred',
                  'P': 'DarkCyan',
@@ -61,6 +68,7 @@ class BasePlot(object):
         self.axis = kwargs.get('axis', None)
         if self.axis is None:
             self.axis = matplotlib.pyplot.gca()
+        self.plot_units = kwargs.get('plot_units', 'kSI')
 
     def __sat_bounds(self, kind, smin=None, smax=None):
         """
@@ -106,7 +114,7 @@ class BasePlot(object):
         """
         Calculates lines for constant iName (iVal) over an interval of xName
         (xVal). Returns (x[],y[]) - a tuple of arrays containing the values
-        in x and y dimensions in kSI units.
+        in x and y dimensions in SI units.
         """
         if len(prop1_vals) != len(prop2_vals):
             raise ValueError(''.join(['We need the same number of x value ',
@@ -215,26 +223,34 @@ class BasePlot(object):
 
         tl_str = "%s - %s Graph for %s"
         if not self.axis.get_title():
-            self.axis.set_title(tl_str % (self.AXIS_LABELS[y_axis_id][0],
-                                          self.AXIS_LABELS[x_axis_id][0],
+            self.axis.set_title(tl_str % (self.AXIS_LABELS[self.plot_units][y_axis_id][0],
+                                          self.AXIS_LABELS[self.plot_units][x_axis_id][0],
                                           filter_fluid_ref(self.fluid_ref)))
         if not self.axis.get_xlabel():
-            self.axis.set_xlabel(' '.join(self.AXIS_LABELS[x_axis_id]))
+            self.axis.set_xlabel(' '.join(self.AXIS_LABELS[self.plot_units][x_axis_id]))
         if not self.axis.get_ylabel():
-            self.axis.set_ylabel(' '.join(self.AXIS_LABELS[y_axis_id]))
+            self.axis.set_ylabel(' '.join(self.AXIS_LABELS[self.plot_units][y_axis_id]))
 
     def _draw_graph(self):
         return
 
-    def scale_plot(self, units='kSI'):
+    def scale_plot(self, plot_units='kSI'):
         """ Scale plot axis with units system
 
         Fluid properties are calculated in SI units for internal use. Axis ticks
         of the plot can be scaled to show data in other unit systems.
+
+        Parameters
+        ----------
+        plot_units : str
+            Unit system for for plotting ('kSI' or 'SI')
+
         """
 
-        xscale = CP.fromSI(self.graph_type[1], 1, units)
-        yscale = CP.fromSI(self.graph_type[0], 1, units)
+        self.plot_units = plot_units
+
+        xscale = CP.fromSI(self.graph_type[1], 1, self.plot_units)
+        yscale = CP.fromSI(self.graph_type[0], 1, self.plot_units)
 
         x_fmt = matplotlib.ticker.FuncFormatter(lambda x, pos: '{0:g}'.format(x*xscale))
         y_fmt = matplotlib.ticker.FuncFormatter(lambda y, pos: '{0:g}'.format(y*yscale))
@@ -261,6 +277,17 @@ class BasePlot(object):
             self.axis.grid(kwargs)
 
     def set_axis_limits(self, limits, units='kSI'):
+        """ Set limits for axes
+
+        Parameters
+        ----------
+        limits : list
+            List of axis limits [xmin, xmax, ymin, ymax]
+        units : str
+            Unit system of the input data ('kSI' or 'SI'), Optional
+
+        """
+
         # convert limits to SI units for internal use
         limits[0:2] = CP.toSI(self.graph_type[1], limits[0:2], units)
         limits[2:] = CP.toSI(self.graph_type[0], limits[2:], units)

--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -125,7 +125,7 @@ class BasePlot(object):
         return numpy.array([x_vals, y_vals])
 
     def _get_sat_lines(self, kind='T', smin=None,
-                       smax=None, num=500, x=[0., 1.]):
+                       smax=None, num=500, x=[0., 1.], line_opts=None):
         """
         Calculates bubble and dew line in the quantities for your plot.
         You can specify if you need evenly spaced entries in either
@@ -182,6 +182,9 @@ class BasePlot(object):
             else:
                 line['opts']['lw'] = 0.75
                 line['opts']['alpha'] = 0.5
+
+            if line_opts is not None:
+                line['opts'].update(line_opts)
 
             sat_lines.append(line)
 

--- a/wrappers/Python/CoolProp/Plots/Plots.py
+++ b/wrappers/Python/CoolProp/Plots/Plots.py
@@ -271,7 +271,7 @@ class IsoLines(BasePlot):
             output = numpy.unique(output)
         return output
 
-    def get_isolines(self, iso_range=[], num=None, rounding=False):
+    def get_isolines(self, iso_range=[], num=None, rounding=False, line_opts=None):
         """
         This is the core method to obtain lines in the dimensions defined
         by 'plot' that describe the behaviour of fluid 'Ref'. The constant
@@ -364,7 +364,7 @@ class IsoLines(BasePlot):
             plot_data = numpy.array([x_vals, y_vals])
 
         elif self.iso_type == 'Q':
-            lines = self._get_sat_lines(x=iso_range)
+            lines = self._get_sat_lines(x=iso_range, line_opts=line_opts)
             return lines
 
         else:
@@ -389,11 +389,15 @@ class IsoLines(BasePlot):
               'type': self.iso_type,
               'opts': {'color': self.COLOR_MAP[self.iso_type], 'lw':0.75, 'alpha':0.5 }
               }
+
+            if line_opts is not None:
+                line['opts'].update(line_opts)
+
             lines.append(line)
 
         return lines
 
-    def draw_isolines(self, iso_range, num=None, rounding=False):
+    def draw_isolines(self, iso_range, num=None, rounding=False, line_opts=None):
         """
         Draw lines with constant values of type 'which' in terms of x and y as
         defined by 'plot'. 'iMin' and 'iMax' are minimum and maximum value between
@@ -415,7 +419,7 @@ class IsoLines(BasePlot):
                               supported, yet..')
 
         if self.iso_type != 'all':
-            lines = self.get_isolines(iso_range, num, rounding)
+            lines = self.get_isolines(iso_range, num, rounding, line_opts)
             drawn_lines = drawLines(self.fluid_ref, lines, self.axis)
             self._plot_default_annotations()
             return drawn_lines
@@ -480,14 +484,32 @@ class PropsPlot(BasePlot):
         self._plot_default_annotations()
         self.scale_plot(units='kSI')
 
-    def draw_isolines(self, iso_type, iso_range, num=10, rounding=False, units='kSI'):
+    def draw_isolines(self, iso_type, iso_range, num=10, rounding=False,
+                      units='kSI', line_opts=None):
+        """ Create isolines
+
+        Parameters
+        ----------
+        iso_type : str
+            Type of the isolines
+        iso_range : list
+            Range between isolines will be created [min, max]
+        num : int
+            Number of the isolines within range, Optional
+        units : str
+            Unit system of the input data ('kSI' or 'SI'), Optional
+        line_opts : dict
+            Line options (please see :func:`matplotlib.pyplot.plot`), Optional
+
+        """
+
         # convert range to SI units for internal use
         iso_range = CP.toSI(iso_type, iso_range, units)
         iso_lines = IsoLines(self.fluid_ref,
                              self.graph_type,
                              iso_type,
                              axis=self.axis)
-        iso_lines.draw_isolines(iso_range, num, rounding)
+        iso_lines.draw_isolines(iso_range, num, rounding, line_opts)
 
 
 def Ts(Ref, Tmin=None, Tmax=None, show=False, axis=None, *args, **kwargs):
@@ -794,7 +816,7 @@ def hs(Ref, Tmin=None, Tmax=None, show=False, axis=None, *args, **kwargs):
         plt._draw_graph()
     return plt.axis
 
-def drawIsoLines(Ref, plot, which, iValues=[], num=0, show=False, axis=None):
+def drawIsoLines(Ref, plot, which, iValues=[], num=0, show=False, axis=None, line_opts=None):
     """
     Draw lines with constant values of type 'which' in terms of x and y as
     defined by 'plot'. 'iMin' and 'iMax' are minimum and maximum value
@@ -823,6 +845,8 @@ def drawIsoLines(Ref, plot, which, iValues=[], num=0, show=False, axis=None):
     axis : :func:`matplotlib.pyplot.gca()`, Optional
         The current axis system to be plotted to.
         (Default: create a new axis system)
+    line_opts : dict
+        Line options (please see :func:`matplotlib.pyplot.plot`), Optional
 
     Examples
     --------
@@ -839,7 +863,7 @@ def drawIsoLines(Ref, plot, which, iValues=[], num=0, show=False, axis=None):
     >>> pyplot.show()
     """
     isolines = IsoLines(Ref, plot, which, axis=axis)
-    lines = isolines.draw_isolines(iValues, num)
+    lines = isolines.draw_isolines(iValues, num=num, line_opts=line_opts)
     if show:
         isolines.show()
     return lines

--- a/wrappers/Python/CoolProp/Plots/Plots.py
+++ b/wrappers/Python/CoolProp/Plots/Plots.py
@@ -456,6 +456,7 @@ class PropsPlot(BasePlot):
 
         Examples
         ---------
+        >>> from CoolProp.State import State
         >>> from CoolProp.Plots import PropsPlot
         >>> plt = PropsPlot('Water', 'Ph')
         >>> plt.show()
@@ -466,6 +467,18 @@ class PropsPlot(BasePlot):
         >>> plt.draw_isolines('P', [100, 2000])
         >>> plt.draw_isolines('D', [2, 600])
         >>> plt.show()
+
+        >>> fluid = 'Water'
+        >>> p_min = 20
+        >>> p_max = 15e3
+        >>> T_max = 550 + 273.15
+        >>> S1 = State(fluid, dict(P=p_min, Q=0))     # condenser outlet
+        >>> S2 = State(fluid, dict(P=p_max, S=S1.s))  # isentropic compression
+        >>> S3 = State(fluid, dict(P=p_max, T=T_max)) # isobaric heating
+        >>> S4 = State(fluid, dict(P=p_min, S=S3.s))  # isentropic expansion
+        >>> Ts = PropsPlot(fluid, 'Ts')
+        >>> Ts.draw_process([S1, S2, S3, S4, S1])
+        >>> Ts.show()
 
         .. note::
 
@@ -521,6 +534,58 @@ class PropsPlot(BasePlot):
                              iso_type,
                              axis=self.axis)
         iso_lines.draw_isolines(iso_range, num, rounding, line_opts, axis_limits)
+
+    def draw_process(self, states, line_opts={'color' : 'r', 'lw' : 1.5}):
+        """ Draw process or cycle from list of State objects
+
+        Parameters
+        ----------
+        states : list
+            List of CoolProp.State.State objects
+        line_opts : dict
+            Line options (please see :func:`matplotlib.pyplot.plot`), Optional
+
+        """
+
+        # plot above other lines
+        line_opts['zorder'] = 10
+
+        for i, state in enumerate(states):
+            if state.Fluid != self.fluid_ref:
+                raise ValueError('Fluid [{0}] from State object does not match PropsPlot fluid [{1}].'.format(state.Fluid, self.fluid_ref))
+
+            if i == 0: continue
+
+            S2 = states[i]
+            S1 = states[i-1]
+            iso = False
+
+            y_name, x_name = self.graph_type.lower().replace('t', 'T')
+
+            x1 = getattr(S1, x_name)
+            x2 = getattr(S2, x_name)
+            y1 = getattr(S1, y_name)
+            y2 = getattr(S2, y_name)
+
+            # search for equal properties between states
+            for iso_type in ['p', 'T', 's', 'h', 'rho']:
+                if getattr(S1, iso_type) == getattr(S2, iso_type):
+                    axis_limits = [[x1, x2], [y1, y2]]
+                    self.draw_isolines(iso_type.upper(), [getattr(S1, iso_type)],
+                                       num=1, units='kSI', line_opts=line_opts,
+                                       axis_limits=axis_limits)
+                    iso = True
+                    break
+
+            # connect states with straight line
+            if not iso:
+                # convert values to SI for plotting
+                x_val = [CP.toSI(x_name.upper(), x1, 'kSI'),
+                         CP.toSI(x_name.upper(), x2, 'kSI')]
+                y_val = [CP.toSI(y_name.upper(), y1, 'kSI'),
+                         CP.toSI(y_name.upper(), y2, 'kSI')]
+                print(x_val, y_val)
+                self.axis.plot(x_val, y_val, **line_opts)
 
 
 def Ts(Ref, Tmin=None, Tmax=None, show=False, axis=None, *args, **kwargs):

--- a/wrappers/Python/CoolProp/Plots/Plots.py
+++ b/wrappers/Python/CoolProp/Plots/Plots.py
@@ -453,6 +453,8 @@ class PropsPlot(BasePlot):
         fig : :func:`matplotlib.pyplot.figure()`, Optional
             The current figure to be plotted to.
             Default: create a new figure
+        plot_units : str
+            Unit system for for plotting (defaults to 'kSI'), Optional
 
         Examples
         ---------
@@ -499,7 +501,7 @@ class PropsPlot(BasePlot):
     def _draw_graph(self):
         self.__draw_region_lines()
         self._plot_default_annotations()
-        self.scale_plot(units='kSI')
+        self.scale_plot(plot_units=self.plot_units)
 
     def draw_isolines(self, iso_type, iso_range, num=10, rounding=False,
                       units='kSI', line_opts=None, axis_limits=None):

--- a/wrappers/Python/CoolProp/Plots/Plots.py
+++ b/wrappers/Python/CoolProp/Plots/Plots.py
@@ -352,18 +352,29 @@ class IsoLines(BasePlot):
             req_prop = self.graph_type[1]
             prop2_name = self.graph_type[0]
 
-        # Calculate the points
-        if self.iso_type == 'Q':
+        # Calculate the data points
+        if self.iso_type == req_prop:
+            x_vals = [[axis_limits[0][0], axis_limits[0][1]]] * len(iso_range)
+            y_vals = [[i, i] for i in iso_range]
+            plot_data = numpy.array([x_vals, y_vals])
+
+        elif self.iso_type == prop2_name:
+            x_vals = [[i, i] for i in iso_range]
+            y_vals = [[axis_limits[1][0], axis_limits[1][1]]] * len(iso_range)
+            plot_data = numpy.array([x_vals, y_vals])
+
+        elif self.iso_type == 'Q':
             lines = self._get_sat_lines(x=iso_range)
             return lines
 
-        # TODO: Determine saturation state if two phase region present
-        x_range = numpy.linspace(axis_limits[0][0], axis_limits[0][1], 1000.)
-        x_mesh = [x_range for i in iso_range]
+        else:
+            # TODO: Determine saturation state if two phase region present
+            x_range = numpy.linspace(axis_limits[0][0], axis_limits[0][1], 1000.)
+            x_mesh = [x_range for i in iso_range]
 
-        plot_data = self._get_fluid_data(req_prop,
-                                         self.iso_type, iso_range,
-                                         prop2_name, x_mesh)
+            plot_data = self._get_fluid_data(req_prop,
+                                             self.iso_type, iso_range,
+                                             prop2_name, x_mesh)
 
         if switch_xy:
             plot_data = plot_data[::-1]

--- a/wrappers/Python/CoolProp/Plots/Plots.py
+++ b/wrappers/Python/CoolProp/Plots/Plots.py
@@ -206,43 +206,32 @@ class IsoLines(BasePlot):
         Generates limits for the axes in terms of x,y defined by 'plot'
         based on temperature and pressure.
 
-        Returns a tuple containing ((xmin, xmax), (ymin, ymax))
+        Returns a list containing [[xmin, xmax], [ymin, ymax]]
         """
+
         # Get current axis limits, be sure to set those before drawing isolines
         # if no limits are set, use triple point and critical conditions
-        X = [CP.PropsSI(self.graph_type[1],
-                        'T', 1.5*CP.PropsSI(self.fluid_ref, 'Tcrit'),
-                        'P', CP.PropsSI(self.fluid_ref, 'ptriple'),
-                        self.fluid_ref),
-             CP.PropsSI(self.graph_type[1],
-                        'T', 1.1*CP.PropsSI(self.fluid_ref, 'Tmin'),
-                        'P', 1.5*CP.PropsSI(self.fluid_ref, 'pcrit'),
-                        self.fluid_ref),
-             CP.PropsSI(self.graph_type[1],
-                        'T', 1.5*CP.PropsSI(self.fluid_ref, 'Tcrit'),
-                        'P', 1.5*CP.PropsSI(self.fluid_ref, 'pcrit'),
-                        self.fluid_ref),
-             CP.PropsSI(self.graph_type[1],
-                        'T', 1.1*CP.PropsSI(self.fluid_ref, 'Tmin'),
-                        'P', CP.PropsSI(self.fluid_ref, 'ptriple'),
-                        self.fluid_ref)]
+        Tcrit = CP.PropsSI(self.fluid_ref, 'Tcrit')
+        Tmin = CP.PropsSI(self.fluid_ref, 'Tmin')
+        pcrit = CP.PropsSI(self.fluid_ref, 'pcrit')
+        ptriple = CP.PropsSI(self.fluid_ref, 'ptriple')
 
-        Y = [CP.PropsSI(self.graph_type[0],
-                        'T', 1.5*CP.PropsSI(self.fluid_ref, 'Tcrit'),
-                        'P', CP.PropsSI(self.fluid_ref, 'ptriple'),
-                         self.fluid_ref),
-             CP.PropsSI(self.graph_type[0],
-                        'T', 1.1*CP.PropsSI(self.fluid_ref, 'Tmin') ,
-                        'P', 1.5*CP.PropsSI(self.fluid_ref, 'pcrit'),
-                        self.fluid_ref),
-             CP.PropsSI(self.graph_type[0],
-                        'T', 1.1*CP.PropsSI(self.fluid_ref, 'Tcrit'),
-                        'P', 1.5*CP.PropsSI(self.fluid_ref, 'pcrit'),
-                        self.fluid_ref),
-             CP.PropsSI(self.graph_type[0],
-                        'T', 1.5*CP.PropsSI(self.fluid_ref, 'Tmin') ,
-                        'P', CP.PropsSI(self.fluid_ref, 'ptriple'),
-                        self.fluid_ref)]
+        T = [1.5*Tcrit, 1.1*Tmin,  1.5*Tcrit, 1.1*Tmin]
+        P = [ptriple,   1.5*pcrit, 1.5*pcrit, ptriple]
+
+        if self.graph_type[1] == 'T':
+            X = T
+        elif self.graph_type[1] == 'P':
+            X = P
+        else:
+            X = CP.PropsSI(self.graph_type[1], 'T', T, 'P', P, self.fluid_ref)
+
+        if self.graph_type[0] == 'T':
+            Y = T
+        elif self.graph_type[0] == 'P':
+            Y = P
+        else:
+            Y = CP.PropsSI(self.graph_type[0], 'T', T, 'P', P, self.fluid_ref)
 
         limits = [[min(X), max(X)], [min(Y), max(Y)]]
         if not self.axis.get_autoscalex_on():


### PR DESCRIPTION
I have added a new method to PropsPlot  class, to allow easys plotting of processes and cycles from a list of State objects as described in #174.
- New draw_process method
- Internal draw_isolines method is used for plotting of the cycle. Thus, all invoked functions are extended to allow new parameters for plot line style and axis limits.
- Updated documentation and added example (rankine cycle)
- Enhanced handling of unit systems for plotting
- Fixed plotting issue caused by 9e832e76ff94b1d963e0049672348cee3137456c
- All tests in `test.plot.py` passes
